### PR TITLE
Units and title case

### DIFF
--- a/cmd/forecast.go
+++ b/cmd/forecast.go
@@ -59,11 +59,11 @@ func Forecast(srID string, d int) {
 		ts := fmt.Sprintf("%d/%d/%d", t.Month(), t.Day(), t.Year())
 
 		cAM := cs[i].AM
-		rangeAM := fmt.Sprintf("%.1f-%.1fft", cAM.MinHeight, cAM.MaxHeight)
+		rangeAM := fmt.Sprintf("%.1f-%.1f%s", cAM.MinHeight, cAM.MaxHeight, convertWaveHeightUnits(cr.Associated.Units.WaveHeight))
 		table.Append([]string{ts, "AM", convertRating(cAM.Rating), rangeAM, cAM.HumanRelation})
 
 		cPM := cs[i].PM
-		rangePM := fmt.Sprintf("%.1f-%.1fft", cAM.MinHeight, cAM.MaxHeight)
+		rangePM := fmt.Sprintf("%.1f-%.1f%s", cAM.MinHeight, cAM.MaxHeight, convertWaveHeightUnits(cr.Associated.Units.WaveHeight))
 		table.Append([]string{ts, "PM", convertRating(cPM.Rating), rangePM, cPM.HumanRelation})
 	}
 
@@ -117,4 +117,12 @@ func getSubregionName(srID string) (string, error) {
 	}
 
 	return t.Name, nil
+}
+
+func convertWaveHeightUnits(u string) string {
+	if u == "FT" {
+		return "ft"
+	} else {
+		return "m"
+	}
 }

--- a/cmd/tide.go
+++ b/cmd/tide.go
@@ -63,9 +63,10 @@ func Tide(sID string, d int) {
 		tt := time.Unix(int64(t.Timestamp), 0)
 		td := fmt.Sprintf("%d/%d/%d", tt.Month(), tt.Day(), tt.Year())
 		ttt := fmt.Sprintf("%02d:%02d", tt.Hour(), tt.Minute())
-		h := strconv.FormatFloat(float64(t.Height), 'f', 2, 32)
+		h := strconv.FormatFloat(float64(t.Height), 'f', 2, 64)
+		fh := fmt.Sprintf("%s%s", h, convertTideHeightUnits(tr.Associated.Units.TideHeight))
 
-		table.Append([]string{td, ttt, t.Type, h})
+		table.Append([]string{td, ttt, convertTideType(t.Type), fh})
 	}
 
 	table.Render()
@@ -108,4 +109,20 @@ func getSpotName(sID string) (string, error) {
 	}
 
 	return t.Name, nil
+}
+
+func convertTideHeightUnits(u string) string {
+	if u == "FT" {
+		return "ft"
+	} else {
+		return "m"
+	}
+}
+
+func convertTideType(t string) string {
+	if t == "HIGH" {
+		return "High"
+	} else {
+		return "Low"
+	}
 }


### PR DESCRIPTION
```
$ gosurf t -s 5842041f4e65fad6a7708bda -d 3
Fetching 3 day(s) of tides for Zippers...
+----------+-------+-------------+---------+
|   DATE   | TIME  | DESCRIPTION | HEIGHT  |
+----------+-------+-------------+---------+
| 8/6/2022 | 03:47 | High        | 1.80ft  |
|          | 07:00 | Low         | 1.64ft  |
|          | 14:54 | High        | 3.58ft  |
|          | 23:10 | Low         | 0.33ft  |
| 8/7/2022 | 06:18 | High        | 2.10ft  |
|          | 09:24 | Low         | 1.94ft  |
|          | 16:22 | High        | 3.90ft  |
| 8/8/2022 | 00:12 | Low         | -0.30ft |
|          | 07:03 | High        | 2.49ft  |
|          | 11:10 | Low         | 1.80ft  |
|          | 17:31 | High        | 4.33ft  |
+----------+-------+-------------+---------+
```

```
$ gosurf f -r 58581a836630e24c44878fe5 -d 3
Fetching 3 day(s) of forecasts for Cabo...
+----------+-------------+--------------+-----------+----------------------+
|   DATE   | TIME OF DAY |    RATING    |   RANGE   |       FORECAST       |
+----------+-------------+--------------+-----------+----------------------+
| 8/5/2022 | AM          | Fair         | 2.0-3.0ft | Thigh to stomach     |
|          | PM          | Poor to Fair | 2.0-3.0ft | Thigh to stomach     |
| 8/6/2022 | AM          | Fair         | 2.0-3.0ft | Thigh to waist       |
|          | PM          | Poor to Fair | 2.0-3.0ft | Thigh to waist       |
| 8/7/2022 | AM          | Fair to Good | 4.0-6.0ft | Chest to overhead    |
|          | PM          | Fair         | 4.0-6.0ft | Head to 2ft overhead |
+----------+-------------+--------------+-----------+----------------------+
```